### PR TITLE
Adds CreateParentStationsForQuais transform

### DIFF
--- a/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/CreateParentStationsForQuais.java
+++ b/onebusaway-gtfs-transformer/src/main/java/org/onebusaway/gtfs_transformer/impl/CreateParentStationsForQuais.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2019 Holger Bruch <hb@mfdz.de>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.gtfs_transformer.impl;
+
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.model.Stop;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs_transformer.services.GtfsTransformStrategy;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Some GTFS-Feeds have stops with IFOPT quai IDs, but no parent stop_places.
+ * Route planners like OpenTripPlanner may cluster quais using their common parentStation.
+ * This strategy requires the quais stop ID to be in IFOPT format, and creates clusters for
+ * all quais with a common stop_place portion. If no stop with this stop_place ID exists,
+ * this strategy creates one.
+ */
+public class CreateParentStationsForQuais implements GtfsTransformStrategy {
+    private static Logger _log = LoggerFactory.getLogger(CreateParentStationsForQuais.class);
+    @Override
+    public String getName() {
+        return this.getClass().getSimpleName();
+    }
+
+    @Override
+    public void run(TransformContext context, GtfsMutableRelationalDao dao) {
+        HashMap<AgencyAndId, Set<Stop>> clusters = collectClusters(dao);
+        createAndSetParentStops(dao, clusters);
+    }
+
+    private void createAndSetParentStops(GtfsMutableRelationalDao dao,
+            HashMap<AgencyAndId, Set<Stop>> clusters) {
+        // iterate over all clusters, if no stop with that Id exists, create one
+        for (Map.Entry<AgencyAndId, Set<Stop>> entry: clusters.entrySet()) {
+            AgencyAndId parentStopId = entry.getKey();
+
+            int cnt = 0;
+            double lat = 0, lon = 0;
+            String name = "";
+
+            // now set parent station for all clustered stops (if not already the parent)
+            for (Stop childStop: entry.getValue()) {
+                // Note: there might be already a stop with stop_place ID, which wasn't yet a parent
+                if (!childStop.getId().equals(parentStopId)) {
+                    childStop.setParentStation(parentStopId.getId());
+                } else {
+                    // Existing stop probably is not yet a parent station
+                    childStop.setLocationType(1);
+                }
+                lat += childStop.getLat();
+                lon += childStop.getLon();
+                cnt++;
+                if ("".equals(name)) {
+                    name = childStop.getName();
+                }
+            }
+
+            if (dao.getStopForId(parentStopId) == null) {
+                Stop stop = new Stop();
+                stop.setId(parentStopId);
+                stop.setName(name);
+                stop.setLocationType(1);
+                stop.setCode(parentStopId.getId());
+                stop.setLat(lat / cnt);
+                stop.setLon(lon / cnt);
+                dao.saveEntity(stop);
+            }
+        }
+    }
+
+    private HashMap<AgencyAndId, Set<Stop>> collectClusters(GtfsMutableRelationalDao dao) {
+        Pattern stopPlacePattern = Pattern.compile("(\\w*:\\w*:\\w*):?(.*)");
+        HashMap<AgencyAndId, Set<Stop>> clusters = new HashMap<>();
+        for (Stop stop: dao.getAllStops()) {
+            Matcher stopPlaceMatcher = stopPlacePattern.matcher(stop.getId().getId());
+            if (!stopPlaceMatcher.matches()) {
+                _log.warn("Stop ID " + stop.getId().getId() + " did not match IFOPT format.");
+                continue;
+            }
+            AgencyAndId newParentId = new AgencyAndId(stop.getId().getAgencyId(),
+                    stopPlaceMatcher.group(1));
+
+            if (!clusters.containsKey(newParentId)) {
+                clusters.put(newParentId, new HashSet<>());
+            }
+            clusters.get(newParentId).add(stop);
+        }
+        return clusters;
+    }
+}

--- a/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/impl/CreateParentStationsForQuaisTest.java
+++ b/onebusaway-gtfs-transformer/src/test/java/org/onebusaway/gtfs_transformer/impl/CreateParentStationsForQuaisTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2018 Tony Laidig <laidig@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.onebusaway.gtfs_transformer.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.onebusaway.gtfs.impl.GtfsRelationalDaoImpl;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.gtfs.services.GtfsMutableRelationalDao;
+import org.onebusaway.gtfs.services.MockGtfs;
+import org.onebusaway.gtfs_transformer.services.TransformContext;
+
+import java.io.IOException;
+
+public class CreateParentStationsForQuaisTest {
+    private GtfsMutableRelationalDao _dao;
+
+    private MockGtfs _gtfs;
+
+    @Before
+    public void setup() throws IOException {
+        _dao = new GtfsRelationalDaoImpl();
+
+        _gtfs = MockGtfs.create();
+        _gtfs.putAgencies(1);
+        _gtfs.putLines("stops.txt",
+                "stop_id,stop_name,stop_lat,stop_lon",
+                "de:08111:6115:1:1,Hauptbahnhof (oben),48.784748077,9.1832141876",
+                "de:08111:6115:1:2,Hauptbahnhof (oben),48.784748077,9.1832141876",
+                "de:08111:6115:2:3,Hauptbahnhof (oben),48.784748077,9.1832141876",
+                "de:08111:6116:1:1,Stadtbibliothek,48.790687561,9.1811532974",
+                "de:08111:6116:1:2,Stadtbibliothek,48.790687561,9.1812076569",
+                "de:08111:6116:3:3,Stadtbibliothek,48.790660858,9.1805820465",
+                "de:08111:6116:3:4,Stadtbibliothek,48.790660858,9.1805820465",
+                "de:08111:6118:1:101,Hauptbahnhof (tief),48.783420563,9.1801605225",
+                "de:08111:6118:1:102,Hauptbahnhof (tief),48.783367157,9.1803379059");
+        _gtfs.putRoutes(2);
+    }
+
+    @Test
+    public void testParentStationsAreCreated() throws IOException {
+        CreateParentStationsForQuais _strategy = new CreateParentStationsForQuais();
+
+        _dao = _gtfs.read();
+
+        assertEquals(1, _dao.getAllAgencies().size());
+        _strategy.run(new TransformContext(), _dao);
+
+        assertEquals("de:08111:6115",
+                _dao.getStopForId(new AgencyAndId("a0", "de:08111:6115:1:1")).getParentStation());
+        assertEquals("Stadtbibliothek",
+                _dao.getStopForId(new AgencyAndId("a0", "de:08111:6116")).getName());
+        assertEquals(48.78339,
+                _dao.getStopForId(new AgencyAndId("a0", "de:08111:6118")).getLat(), 0.0001);
+        assertEquals(9.1802,
+                _dao.getStopForId(new AgencyAndId("a0", "de:08111:6118")).getLon(), 0.0001);
+        assertEquals(1,
+                _dao.getStopForId(new AgencyAndId("a0", "de:08111:6118")).getLocationType());
+
+    }
+}


### PR DESCRIPTION
**Summary:**

Adds a transform to create parent stations for stops with equivalent IFOPT station ID.

- [ ] Run the unit tests with `mvn test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - short description of fix and changes"
- [ ] Linked all relevant issues

Signed-off-by: Holger Bruch <hb@mfdz.de>